### PR TITLE
Wait for Xcode to finish launching so NSApp will be available, needed…

### DIFF
--- a/XCoverage/COVCoverage.m
+++ b/XCoverage/COVCoverage.m
@@ -78,6 +78,8 @@ static NSString *const COVManualSearchLocation = @"XCoverage-COVManualSearchLoca
 
 - (void)setup
 {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationDidFinishLaunchingNotification object:nil];
+    
     _serialQueue = dispatch_queue_create("XCoverageQueue", DISPATCH_QUEUE_SERIAL);
     _previousLocationContext = [[COVPreviousLocationContext alloc] init];
     

--- a/XCoverage/COVCoverage.m
+++ b/XCoverage/COVCoverage.m
@@ -67,12 +67,21 @@ static NSString *const COVManualSearchLocation = @"XCoverage-COVManualSearchLoca
 {
     self = [super init];
     if (self) {
-        _serialQueue = dispatch_queue_create("XCoverageQueue", DISPATCH_QUEUE_SERIAL);
-        _previousLocationContext = [[COVPreviousLocationContext alloc] init];
-
-        [self cov_addMenuItems];
+        if([[NSRunningApplication currentApplication] isFinishedLaunching]){
+            [self setup];
+        } else {
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(setup) name:NSApplicationDidFinishLaunchingNotification object:nil];
+        }
     }
     return self;
+}
+
+- (void)setup
+{
+    _serialQueue = dispatch_queue_create("XCoverageQueue", DISPATCH_QUEUE_SERIAL);
+    _previousLocationContext = [[COVPreviousLocationContext alloc] init];
+    
+    [self cov_addMenuItems];
 }
 
 - (void)dealloc

--- a/XCoverage/Info.plist
+++ b/XCoverage/Info.plist
@@ -24,6 +24,7 @@
 	<string>0.8</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>


### PR DESCRIPTION
This will fix the problem for XCode 6.3 and also adds the compatibility UUID for XCode 6.3.2

Solution found from a similar problem with the Dash plugin.
https://github.com/omz/Dash-Plugin-for-Xcode/commit/3014f12c4e91a6be3a0521600f65879acae05b0a
