### PR TITLE
Xcode 6.4 compatibility UUID

### DIFF
--- a/XCoverage/Info.plist
+++ b/XCoverage/Info.plist
@@ -33,6 +33,7 @@
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
 		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
+		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>COVCoverage</string>


### PR DESCRIPTION
XCoverage does work in 6.4
